### PR TITLE
Fix Zigbee2MQTT app metadata

### DIFF
--- a/haus-zigbee2mqtt/docker-compose.yml
+++ b/haus-zigbee2mqtt/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
   app_proxy:
     environment:
-      APP_HOST: zigbee2mqtt_web_1
+      APP_HOST: web
       APP_PORT: 8080
 
   web:
-    image: ghcr.io/koenkk/zigbee2mqtt:latest@sha256:latest
+    image: ghcr.io/koenkk/zigbee2mqtt:latest
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/haus-zigbee2mqtt/umbrel-app.yml
+++ b/haus-zigbee2mqtt/umbrel-app.yml
@@ -1,5 +1,5 @@
 manifestVersion: 1.1
-id: zigbee2mqtt
+id: haus-zigbee2mqtt
 category: automation
 name: Zigbee2MQTT
 version: "1.34.0"
@@ -15,10 +15,6 @@ dependencies: []
 repo: https://github.com/Koenkk/zigbee2mqtt
 support: https://github.com/Koenkk/zigbee2mqtt/issues
 port: 8080
-gallery:
-  - 1.jpg
-  - 2.jpg
-  - 3.jpg
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
## Summary
- correct app id to follow `haus-` prefix rule
- remove missing gallery entries
- use official zigbee2mqtt image
- match `APP_HOST` with service name

## Testing
- `curl -I https://ghcr.io`

------
https://chatgpt.com/codex/tasks/task_e_6852506ddd348322876711128dea29cb